### PR TITLE
feat: add update all branches vscode task

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,32 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Update All Git Branches (Linux/macOS)",
+            "type": "shell",
+            "command": "git fetch --all && git branch | sed 's/* //' | xargs -I {} git pull origin {}",
+            "problemMatcher": [],
+            "group": {
+                "kind": "build",
+                "isDefault": false
+            },
+            "presentation": {
+                "reveal": "always"
+            }
+            
+        },
+        {
+            "label": "Update All Git Branches (Windows)",
+            "type": "shell",
+            "command": "git fetch --all && for /f \"tokens=*\" %i in ('git branch') do git pull origin %i",
+            "problemMatcher": [],
+            "group": {
+                "kind": "build",
+                "isDefault": false
+            },
+            "presentation": {
+                "reveal": "always"
+            }
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -14,19 +14,6 @@
                 "reveal": "always"
             }
             
-        },
-        {
-            "label": "Update All Git Branches (Windows)",
-            "type": "shell",
-            "command": "git fetch --all && for /f \"tokens=*\" %i in ('git branch') do git pull origin %i",
-            "problemMatcher": [],
-            "group": {
-                "kind": "build",
-                "isDefault": false
-            },
-            "presentation": {
-                "reveal": "always"
-            }
         }
     ]
 }


### PR DESCRIPTION
Don't merge yet, needs to be tested for windows

This exists cause it's annoying to go through each branch and update it individually after a new PR is merged into main